### PR TITLE
fix: make package names and references for the project consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Rewrite Header Regex is a middleware plugin for [Traefik](https://traefik.io) wh
 [pilot]
   token = "xxxx"
 
-[experimental.plugins.rewritebody]
-  modulename = "github.com/domainesia/traefik-plugin-rewriteheader"
+[experimental.plugins.reformatheader]
+  modulename = "github.com/domainesia/traefik-plugin-reformatheader"
   version = "v0.0.1"
 ```
 
@@ -26,7 +26,7 @@ To configure the Rewrite Head plugin you should create a [middleware](https://do
     [http.routers.my-router]
       rule = "Host(`localhost`)"
       service = "my-service"
-      middlewares = ["rewriteheader"]
+      middlewares = ["reformatheader"]
 
   [http.services]
     [http.services.my-service.loadBalancer]
@@ -34,7 +34,7 @@ To configure the Rewrite Head plugin you should create a [middleware](https://do
         url = "http://127.0.0.1"
 
   [http.middlewares]
-    [http.middlewares.rewriteheader.plugin.dev]
+    [http.middlewares.reformatheader.plugin.dev]
       fromhead  = "X-TargetHeader" //required
       regex     = "f(oo).?"        //required
       create    = "X-NewHeader"    //required

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/domainesia/traefik-plugin-rewriteheader
+module github.com/domainesia/traefik-plugin-reformatheader
 
 go 1.14

--- a/reformatheader.go
+++ b/reformatheader.go
@@ -1,4 +1,4 @@
-package traefik_plugin_rewriteheader
+package traefik_plugin_reformatheader
 
 import (
 	"context"
@@ -9,10 +9,10 @@ import (
 
 // Config the plugin configuration.
 type Config struct {
-	FromHead  string `json:"fromhead,omitempty"`  // target header
-	Regex     string `json:"regex,omitempty"`     // variable for creating a new header that will store data from the target header
-	Create    string `json:"create,omitempty"`    // creating a new header for store extracted data from the old
-	Format    string `json:"format,omitempty"`    // transform captured data on the new header
+	FromHead string `json:"fromhead,omitempty"` // target header
+	Regex    string `json:"regex,omitempty"`    // variable for creating a new header that will store data from the target header
+	Create   string `json:"create,omitempty"`   // creating a new header for store extracted data from the old
+	Format   string `json:"format,omitempty"`   // transform captured data on the new header
 }
 
 // CreateConfig creates and initializes the plugin configuration.


### PR DESCRIPTION
I attempted to run this plugin as a local/private plugin utilising the following guide: https://traefik.io/blog/using-private-plugins-in-traefik-proxy-2-5/ and noticed while the project/package was renamed a number of elements were missed which in turn the plugin didn't work.

I have corrected those errors and now have a working instance locally which allows me to utilise this plugin. 